### PR TITLE
Role change bug fix

### DIFF
--- a/test/roleaction-routes.js
+++ b/test/roleaction-routes.js
@@ -252,6 +252,36 @@ describe('service Api roleaction routes', function() {
 
       return utils.shouldBeBadRequest(promise, 701);
     });
+
+    it('should change description, when onlu description change is requested', function () {
+      return saveRecordWithActions([], 'some description')
+        .then(utils.login)
+        .then(function(res) {
+          res.should.have.status(200);
+
+          return chai.request(app)
+            .put('/um/roles/' + defaultRole)
+            .set('authorization', res.text)
+            .send({
+              name: defaultRole,
+              description: 'description'
+            });
+        })
+        .then(function(res) {
+          res.should.have.status(200);
+
+          should.exist(res.body);
+
+          res.body.should.have.property('success', true);
+
+          return findRole(defaultRole);
+        })
+        .then(function (role) {
+          should.exist(role);
+
+          role.should.have.property('description', 'description');
+        });
+    });
   });
 
   describe('DELETE roles/:roleName', function() {

--- a/umpack.js
+++ b/umpack.js
@@ -445,7 +445,7 @@ router.put('/roles/:roleName', isAuthorized, function (req, res, next) {
 
   var promise = Role.findOne({name: roleInfo.name})
     .then(function (role) {
-      if (role) throw apiError(INTERNAL_STATUS.ROLE_ALREADY_EXISTS);
+      if (role  && roleInfo.name !== req.params.roleName) throw apiError(INTERNAL_STATUS.ROLE_ALREADY_EXISTS);
 
       return Role.findOne({name: req.params.roleName});
     })


### PR DESCRIPTION
when client wanted to change only `description` , `PUT /roles/:roleName` was throwing `ROLE_ALREADY_EXISTS`. this error was being thrown because `roleName` parameter and request body field `name` was same. 